### PR TITLE
Adding authentication support to hilink

### DIFF
--- a/hilink.go
+++ b/hilink.go
@@ -262,7 +262,7 @@ func (c *Client) NewSessionAndTokenID() (string, string, error) {
 
 	// convert to strings
 	s, ok := sesInfo.(string)
-	if !ok || !strings.HasPrefix(s, "SessionID=") {
+	if !ok {
 		return "", "", ErrInvalidResponse
 	}
 	t, ok := tokInfo.(string)
@@ -270,7 +270,10 @@ func (c *Client) NewSessionAndTokenID() (string, string, error) {
 		return "", "", ErrInvalidResponse
 	}
 
-	return s[len("SessionID="):], t, nil
+	if strings.HasPrefix(s, "SessionID=") {
+		s = s[len("SessionID="):]
+	}
+	return s, t, nil
 }
 
 // SetSessionAndTokenID sets the sessionID and tokenID for the Client.

--- a/opts.go
+++ b/opts.go
@@ -1,6 +1,9 @@
 package hilink
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -23,6 +26,19 @@ func URL(rawurl string) Option {
 		c.url, err = url.Parse(rawurl)
 
 		return err
+	}
+}
+
+// Auth is an option specifying the identifier and password to use.
+// The option is ignored if id is an empty string.
+func Auth(id, pw string) Option {
+	return func(c *Client) error {
+		if id != "" {
+			c.authID = id
+			h := sha256.Sum256([]byte(pw))
+			c.authPW = id + base64.StdEncoding.EncodeToString([]byte(hex.EncodeToString(h[:])))
+		}
+		return nil
 	}
 }
 

--- a/util.go
+++ b/util.go
@@ -132,7 +132,7 @@ func boolToString(b bool) string {
 var ErrorCodeMessageMap = map[string]string{
 	"-1":     "system not available",
 	"100002": "not supported by firmware or incorrect API path",
-	"100003": "no power",
+	"100003": "access denied",
 	"100004": "system busy",
 	"100005": "unknown error",
 	"100006": "invalid parameter",

--- a/util.go
+++ b/util.go
@@ -132,7 +132,7 @@ func boolToString(b bool) string {
 var ErrorCodeMessageMap = map[string]string{
 	"-1":     "system not available",
 	"100002": "not supported by firmware or incorrect API path",
-	"100003": "access denied",
+	"100003": "unauthorized",
 	"100004": "system busy",
 	"100005": "unknown error",
 	"100006": "invalid parameter",


### PR DESCRIPTION
This pull request adds authentication to the hilink package. 

To use authentication, instantiate the client with the following instruction:
`c := hilink.NewClient(hilink.Auth("admin", "myPassword"))`

In the current hilink implementation, there is no automatic new session setup when it expires. The user would have to instantiate a new client to get an authenticated session. You might want to change this so that the client automatically setup a new session and authenticates itself when the session is expired. I don't think the end user should have to call `NewSessionAndToken()` and `SetSessionAndTokenID()` himself. All you need is call the `login()` to authenticate. 

In addition, I removed a small problem in `NewSessionAndTokenID()` that would  prevent completion without error with my device (4G router B525S23a). The protocol change is that the SesInfo value doesn't start with "SessionID=" in my case. 

Finally, I change the error text "no power" to "unauthorized" to provide a better hint on the cause, and the `Auth()` option. 

